### PR TITLE
Fix broken tests

### DIFF
--- a/tests/functional/README.rst
+++ b/tests/functional/README.rst
@@ -5,6 +5,23 @@ Marconi's functional tests treat Marconi as a black box. In other
 words, the API calls attempt to simulate an actual user. Unlike unit tests,
 the functional tests do not use mockendpoints.
 
+Configuring the tests
+---------------------
+
+(NOTE: take the following section with salt; it's my best guess of how
+this works)
+
+The tests look in ``$MARCONI_TESTS_CONFIGS_DIR`` for config files. The
+two files that are relevant to the functional tests are
+``functional-tests.conf`` and ``functional-marconi.conf``.
+``functional-tests.conf`` contains the test configuration.
+``functional-marconi.conf`` is a (partial?) mirror of the configuration
+of *the server you are testing against*. In particular, the values in
+the "limits" section must match the target server. They are used to
+check for correct rejection of requests that exceed the limits.
+
+There are example configs in this repository under ``tests/etc``.
+
 
 Running functional tests (With Tox)
 -----------------------------------

--- a/tests/functional/wsgi/v1/test_claims.py
+++ b/tests/functional/wsgi/v1/test_claims.py
@@ -61,7 +61,8 @@ class TestClaims(base.FunctionalTestBase):
         actual_message_count = len(result.json())
         self.assertMessageCount(actual_message_count, message_count)
 
-        response_headers = set(result.headers.keys())
+        response_headers = set(k.lower() for k in result.headers.keys())
+
         self.assertIsSubset(self.headers_response_with_body, response_headers)
 
     test_claim_messages.tags = ['smoke', 'positive']

--- a/tests/functional/wsgi/v1/test_messages.py
+++ b/tests/functional/wsgi/v1/test_messages.py
@@ -52,7 +52,7 @@ class TestMessages(base.FunctionalTestBase):
         result = self.client.post(data=doc)
         self.assertEqual(result.status_code, 201)
 
-        response_headers = set(result.headers.keys())
+        response_headers = set(k.lower() for k in result.headers.keys())
         self.assertIsSubset(self.headers_response_with_body, response_headers)
 
         # GET on posted message

--- a/tests/functional/wsgi/v1/test_messages.py
+++ b/tests/functional/wsgi/v1/test_messages.py
@@ -223,19 +223,20 @@ class TestMessages(base.FunctionalTestBase):
 
     test_message_partial_get.tags = ['negative']
 
-    def test_message_bulk_insert_60(self):
+    def test_message_bulk_insert_too_many(self):
         """Insert more than max allowed messages.
 
         Marconi allows  a maximum of 50 message per POST.
         """
-        doc = helpers.create_message_body(messagecount=60)
+        limit = self.limits.message_paging_uplimit
+        doc = helpers.create_message_body(messagecount=limit+1)
 
         result = self.client.post(data=doc)
         self.assertEqual(result.status_code, 400)
 
-    test_message_bulk_insert_60.tags = ['negative']
+    test_message_bulk_insert_too_many.tags = ['negative']
 
-    @ddt.data(10000000000000000000, -100, 0, 30, -10000000000000000000)
+    @ddt.data(10000000000000000000, -100, 0, -10000000000000000000)
     def test_message_get_invalid_limit(self, limit):
         """Get Messages with invalid value for limit.
 
@@ -246,6 +247,16 @@ class TestMessages(base.FunctionalTestBase):
         self.assertEqual(result.status_code, 400)
 
     test_message_get_invalid_limit.tags = ['negative']
+
+    def test_message_get_too_many(self):
+        """ Get more messages than allowed by the (configurable) limit
+
+        The default limit is 20
+        """
+        limit = self.limits.message_paging_uplimit
+        params = {'limit': limit+1}
+        result = self.client.get(params=params)
+        self.assertEqual(result.status_code, 400)
 
     def test_message_bulk_delete_negative(self):
         """Delete more messages than allowed in a single request.

--- a/tests/unit/queues/transport/wsgi/test_queue_lifecycle.py
+++ b/tests/unit/queues/transport/wsgi/test_queue_lifecycle.py
@@ -63,8 +63,8 @@ class QueueLifecycleBaseTest(base.TestBase):
         self.simulate_put(path, project_id)
         self.assertEqual(self.srmock.status, falcon.HTTP_201)
 
-        location = ('Location', '/v1/queues/gumshoe')
-        self.assertIn(location, self.srmock.headers)
+        location = ('location', '/v1/queues/gumshoe')
+        self.assertIn(location, ((k.lower(), v) for k, v in self.srmock.headers))
 
         # Ensure queue existence
         self.simulate_head(path, project_id)

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -23,6 +23,14 @@ from marconi import tests as testing
 class TestVersion(testing.TestBase):
 
     def test_correct_hash(self):
+        # As far as I can tell the following can never work. It wants to
+        # look up a git tag that isn't a valid version number, and pbr
+        # rightly complains about that. Maybe _get_version_from_git's
+        # behavior has changed since this was written -- it is, after
+        # all, a private library function, and we shouldn't be depending
+        # on it.
+
+        self.skipTest("FIXME: Broken test")
         version = pbr.packaging._get_version_from_git('201X.X')
         if version is None:
             self.skipTest('Unable to obtain version from git')


### PR DESCRIPTION
Several existing tests are either broken, or make invalid assumptions that create false failures.